### PR TITLE
Add db:generate and db:migrate command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# variables for running drizzle-kit on your production database
+# bun run db:migrate:prod
+CLOUDFLARE_D1_ACCOUNT_ID=
+DATABASE=
+CLOUDFLARE_D1_API_TOKEN=

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ Cloudflare [Bindings](https://developers.cloudflare.com/pages/functions/bindings
 For detailed instructions on setting up bindings, refer to the Cloudflare documentation.
 
 ## Database Migrations
-
+To generate migrations files:
+- `bun run db:generate`
 To apply database migrations:
-- For development: `bun run migrate:dev`
-- For production: `bun run migrate:prd`
+- For development: `bun run db:migrate:dev`
+- For production: `bun run db:migrate:prd`
 
 ## Cloudflare R2 Bucket CORS / File Upload
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "preview": "bun pages:build && wrangler pages dev",
     "deploy": "bun pages:build && wrangler pages deploy",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv env.d.ts",
-    "setup": "bun run scripts/setup.ts"
+    "setup": "bun run scripts/setup.ts",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate:dev": "drizzle-kit migrate",
+    "db:migrate:prod": "NODE_ENV=production drizzle-kit migrate"
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.4.2",


### PR DESCRIPTION
Tested with my setup. I am able to migrate for both prod db and dev local db.

I am adding `db:migrate:dev` instead of `migrate:dev`. Feel like prefixing `db:` is a common pattern.